### PR TITLE
YA-71 Соединить canvas и игровой движок

### DIFF
--- a/packages/client/src/components/Canvas/Canvas.tsx
+++ b/packages/client/src/components/Canvas/Canvas.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useRef, memo, FC } from 'react'
+import { GameDeskSegmentKeyType, IGamingDesk } from '../../gameCore/types'
 import { destinationSquare } from '../../utils'
 import { CanvasEngine } from '../../utils/canvasEngine/canvasEngine'
-import { IElement } from '../../utils/canvasEngine/canvasTypings'
 import { DPI_HEIGHT, DPI_WIDTH } from '../../utils/consts'
 
 interface ICanvasProps {
-  handleClickOnCanvas: (grid: string) => void
-  elements: IElement[]
+  handleClickOnCanvas: (grid: GameDeskSegmentKeyType) => boolean
+  elements: IGamingDesk
 }
 
 export const Canvas: FC<ICanvasProps> = memo(
@@ -36,9 +36,9 @@ export const Canvas: FC<ICanvasProps> = memo(
         event.nativeEvent.offsetX,
         event.nativeEvent.offsetY
       )
-      const cell = `${y}${x}`
-      game.click(cell)
-      handleClickOnCanvas(cell)
+      const cell = `${y}${x}` as GameDeskSegmentKeyType
+      const isRender = handleClickOnCanvas(cell)
+      game.click(isRender)
     }
 
     return (

--- a/packages/client/src/components/game/Hand/Hand.tsx
+++ b/packages/client/src/components/game/Hand/Hand.tsx
@@ -1,5 +1,5 @@
 import Box from '@mui/material/Box/Box'
-import React, { FC, useState } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 import { CardsDeckType } from '../../../gameCore/types'
 import { ImageByName } from '../../../utils/consts'
 import { CardFace } from '../CardFace/CardFace'
@@ -26,7 +26,7 @@ const styles = {
   },
   opponentActiveCard: {
     position: 'absolute',
-    transform: 'scale(0.7, 0.7) translate(0, 30%);',
+    transform: 'scale(0.7, 0.7) translate(-300px, 20%);',
     transformOrigin: 'right bottom',
     transition: 'transform 0.5s ease-in-out',
     cursor: 'pointer',
@@ -40,6 +40,10 @@ export const Hand: FC<IHand> = ({
   handleChoiceActiveCardInHand,
 }) => {
   const [activeCardId, setActiveCardId] = useState<string | null>(null)
+
+  useEffect(() => {
+    setActiveCardId(null)
+  }, [isActive])
 
   const handleClickOnCard = (id: string) => () => {
     if (!activeCardId) {
@@ -59,7 +63,7 @@ export const Hand: FC<IHand> = ({
   }
 
   return (
-    <Box sx={{ display: 'flex' }}>
+    <Box sx={{ display: 'flex', height: '148px' }}>
       {cardsInHand.map(card => {
         const { id, name } = card
         const srcImg = ImageByName[name]

--- a/packages/client/src/gameCore/consts.ts
+++ b/packages/client/src/gameCore/consts.ts
@@ -1,6 +1,17 @@
+import { CurrentGamer } from './models/Game'
+import { GameDeskSegmentKeyType } from './types'
+
 export const BASE_COUNT_OF_CARDS_IN_HAND = 6
 export const COUNT_CARDS_IN_PLAYER_DECK = 30
 
 export const endGameMessage = {
   noCardsInDeck: 'Карты в вашей колоде закончились! Вы проиграли!',
+}
+
+export const accessibleGridForLanding: Record<
+  CurrentGamer,
+  GameDeskSegmentKeyType[]
+> = {
+  user: ['B1', 'B2', 'C2'],
+  opponent: ['A4', 'B4', 'B5'],
 }

--- a/packages/client/src/gameCore/models/Desk/Desk.test.ts
+++ b/packages/client/src/gameCore/models/Desk/Desk.test.ts
@@ -10,6 +10,6 @@ beforeEach(() => (desk = new Desk({ opponentHeadquarters, userHeadquarters })))
 
 test('Desk start configuration', () => {
   const gamingDesk = desk.getGamingDesk()
-  const userHeadquartersName = gamingDesk.c1.name
+  const userHeadquartersName = gamingDesk.C1?.getVehicle().name
   expect(userHeadquartersName).toBe(userHeadquarters.name)
 })

--- a/packages/client/src/gameCore/models/Desk/index.ts
+++ b/packages/client/src/gameCore/models/Desk/index.ts
@@ -1,14 +1,137 @@
-import { IDesk, IGamingDesk } from '../../types'
+import { ElementsCreator } from '../../../utils/canvasEngine/canvasElement'
+import { accessibleGridForLanding } from '../../consts'
+import {
+  IDesk,
+  IGamingDesk,
+  GameDeskSegmentKeyType,
+  VehicleOwnerType,
+} from '../../types'
 import { getNewGamingDesk } from '../../utils'
+import { CurrentGamer } from '../Game'
+import { Tank } from '../TanksDeck'
+import { Vehicle } from '../Vehicle'
 
 export class Desk {
   public gamingDesk: IGamingDesk
 
   constructor({ userHeadquarters, opponentHeadquarters }: IDesk) {
-    this.gamingDesk = getNewGamingDesk(userHeadquarters, opponentHeadquarters)
+    const userHeadquartersSkin = new ElementsCreator({
+      type: 'card',
+      targetСell: 'C1',
+      tankBringsResources: userHeadquarters.bringsResources,
+      tankDamage: userHeadquarters.damage,
+      tankHealth: userHeadquarters.health,
+      tankName: userHeadquarters.name,
+      tankType: userHeadquarters.type,
+    })
+    const opponentHeadquartersSkin = new ElementsCreator({
+      type: 'card',
+      targetСell: 'A5',
+      tankBringsResources: opponentHeadquarters.bringsResources,
+      tankDamage: opponentHeadquarters.damage,
+      tankHealth: opponentHeadquarters.health,
+      tankName: opponentHeadquarters.name,
+      tankType: opponentHeadquarters.type,
+    })
+    this.gamingDesk = getNewGamingDesk(
+      new Vehicle({
+        vehicle: userHeadquarters,
+        skin: userHeadquartersSkin,
+        vehicleOwner: 'user',
+      }),
+      new Vehicle({
+        vehicle: opponentHeadquarters,
+        skin: opponentHeadquartersSkin,
+        vehicleOwner: 'opponent',
+      })
+    )
   }
 
   public getGamingDesk() {
     return this.gamingDesk
+  }
+
+  isAccessibleGridForLanding(
+    grid: GameDeskSegmentKeyType,
+    currentGamer: CurrentGamer
+  ) {
+    return (
+      this.gamingDesk[grid] === null &&
+      accessibleGridForLanding[currentGamer].includes(grid)
+    )
+  }
+
+  public addVehicleOnDesk(
+    target: GameDeskSegmentKeyType,
+    vehicle: Tank,
+    vehicleOwner: VehicleOwnerType
+  ) {
+    if (
+      target === 'A5' ||
+      target === 'C1' ||
+      this.gamingDesk[target] !== null
+    ) {
+      return null
+    }
+    const skin = new ElementsCreator({
+      type: 'card',
+      targetСell: target,
+      tankBringsResources: vehicle.bringsResources,
+      tankDamage: vehicle.damage,
+      tankHealth: vehicle.health,
+      tankName: vehicle.name,
+      tankType: vehicle.type,
+    })
+    this.gamingDesk[target] = new Vehicle({ vehicle, vehicleOwner, skin })
+    return this.gamingDesk
+  }
+
+  public toggleActiveVehicleOnDesk(
+    target: GameDeskSegmentKeyType,
+    currentGamer: CurrentGamer
+  ) {
+    const element = this.gamingDesk[target]
+    if (element !== null && element.isYouVehicleOwner(currentGamer)) {
+      element.skin.toggleActiveElementState()
+      return true
+    }
+    return false
+  }
+
+  public moveVehicleOnDesk(
+    start: GameDeskSegmentKeyType,
+    target: GameDeskSegmentKeyType
+  ) {
+    if (
+      start === 'A5' ||
+      start === 'C1' ||
+      this.gamingDesk[start] === null ||
+      target === 'A5' ||
+      target === 'C1' ||
+      this.gamingDesk[target] !== null
+    ) {
+      return null
+    }
+
+    const isMove = this.gamingDesk[start]?.letsMove(target)
+    if (isMove) {
+      this.gamingDesk[target] = this.gamingDesk[start]
+      this.gamingDesk[start] = null
+      return this.gamingDesk
+    }
+    return null
+  }
+
+  public deleteVehicleOnDesk(target: GameDeskSegmentKeyType) {
+    if (
+      target === 'A5' ||
+      target === 'C1' ||
+      this.gamingDesk[target] === null
+    ) {
+      return null
+    }
+    const targetTank = this.gamingDesk[target]
+    this.gamingDesk[target] = null
+    return targetTank
   }
 }

--- a/packages/client/src/gameCore/models/Game/index.ts
+++ b/packages/client/src/gameCore/models/Game/index.ts
@@ -3,7 +3,7 @@ import { IUserData } from '../../types'
 import { Desk } from '../Desk'
 import { getRandomInt, nanoid } from '../../utils'
 
-enum CurrentGamer {
+export enum CurrentGamer {
   user = 'user',
   opponent = 'opponent',
 }

--- a/packages/client/src/gameCore/models/Vehicle/Vehicle.test.ts
+++ b/packages/client/src/gameCore/models/Vehicle/Vehicle.test.ts
@@ -1,0 +1,36 @@
+import { Vehicle } from '.'
+import { ElementsCreator } from '../../../utils/canvasEngine/canvasElement'
+import { decksOfTanksByTier } from '../TanksDeck'
+
+let newVehicle: Vehicle
+
+const tank = decksOfTanksByTier.first[0]
+const targetСell = 'A4'
+const mockSkin = new ElementsCreator({
+  type: 'card',
+  tankBringsResources: tank.bringsResources,
+  tankDamage: tank.damage,
+  tankHealth: tank.health,
+  tankName: tank.name,
+  targetСell,
+  tankType: tank.type,
+})
+
+beforeEach(
+  () =>
+    (newVehicle = new Vehicle({
+      vehicleOwner: 'user',
+      vehicle: tank,
+      skin: mockSkin,
+    }))
+)
+
+test('New vehicle create', () => {
+  const tankName = newVehicle.getVehicle().name
+  expect(tankName).toBe(tank.name)
+})
+
+test('Vehicle skin', () => {
+  const target = newVehicle.skin.targetСell
+  expect(target).toBe(targetСell)
+})

--- a/packages/client/src/gameCore/models/Vehicle/index.ts
+++ b/packages/client/src/gameCore/models/Vehicle/index.ts
@@ -1,0 +1,51 @@
+import { ElementsCreator } from '../../../utils/canvasEngine/canvasElement'
+import { GameDeskSegmentKeyType, IVehicle } from '../../types'
+import { getMaxMoves } from '../../utils'
+import { CurrentGamer } from '../Game'
+import { Headquarters } from '../HeadquartersDeck'
+
+export class Vehicle {
+  private vehicle
+  private vehicleOwner
+  private maxMoves: number
+  private currentMoves: number
+  public skin: ElementsCreator
+
+  constructor({ vehicle, vehicleOwner, skin }: IVehicle) {
+    this.vehicle = vehicle
+    this.skin = skin
+    this.vehicleOwner = vehicleOwner
+    this.maxMoves =
+      vehicle instanceof Headquarters ? 0 : getMaxMoves(vehicle.type)
+    this.currentMoves = this.maxMoves > 1 ? 1 : 0
+  }
+
+  public getVehicleOwner() {
+    return this.vehicleOwner
+  }
+
+  public isYouVehicleOwner(currentGamer: CurrentGamer) {
+    return this.vehicleOwner === currentGamer
+  }
+
+  public getVehicle() {
+    return this.vehicle
+  }
+
+  public getCurrentMoves() {
+    return this.currentMoves
+  }
+
+  public letsMove(target: GameDeskSegmentKeyType) {
+    if (this.currentMoves > 0) {
+      this.currentMoves -= 1
+      this.skin.moveActiveElement(target)
+      return true
+    }
+    return false
+  }
+
+  public refreshMoves() {
+    this.currentMoves = this.maxMoves
+  }
+}

--- a/packages/client/src/gameCore/types.ts
+++ b/packages/client/src/gameCore/types.ts
@@ -1,7 +1,9 @@
+import { ElementsCreator } from '../utils/canvasEngine/canvasElement'
 import { Headquarters } from './models/HeadquartersDeck'
 import { Order } from './models/OrdersDeck'
 import { Platoon } from './models/PlatoonsDeck'
 import { Tank } from './models/TanksDeck'
+import { Vehicle } from './models/Vehicle'
 
 export type TankType = 'тяжёлый' | 'средний' | 'лёгкий' | 'ПТ-САУ' | 'САУ'
 export type PlatoonsType =
@@ -97,22 +99,30 @@ export interface IDesk {
   opponentHeadquarters: Headquarters
 }
 
-export type GameDeskSegmentType = Tank | null
+export type GameDeskSegmentKeyType =
+  | 'A1'
+  | 'A2'
+  | 'A3'
+  | 'A4'
+  | 'A5'
+  | 'B1'
+  | 'B2'
+  | 'B3'
+  | 'B4'
+  | 'B5'
+  | 'C1'
+  | 'C2'
+  | 'C3'
+  | 'C4'
+  | 'C5'
 
-export interface IGamingDesk {
-  a1: GameDeskSegmentType
-  a2: GameDeskSegmentType
-  a3: GameDeskSegmentType
-  a4: GameDeskSegmentType
-  a5: Headquarters
-  b1: GameDeskSegmentType
-  b2: GameDeskSegmentType
-  b3: GameDeskSegmentType
-  b4: GameDeskSegmentType
-  b5: GameDeskSegmentType
-  c1: Headquarters
-  c2: GameDeskSegmentType
-  c3: GameDeskSegmentType
-  c4: GameDeskSegmentType
-  c5: GameDeskSegmentType
+export type IGamingDesk = {
+  [key in GameDeskSegmentKeyType]: Vehicle | null
+}
+
+export type VehicleOwnerType = 'user' | 'opponent'
+export interface IVehicle {
+  vehicle: Tank | Headquarters
+  vehicleOwner: VehicleOwnerType
+  skin: ElementsCreator
 }

--- a/packages/client/src/gameCore/utils.ts
+++ b/packages/client/src/gameCore/utils.ts
@@ -1,5 +1,5 @@
 import BaseCard from './models/BaseCard'
-import { Headquarters } from './models/HeadquartersDeck'
+import { Vehicle } from './models/Vehicle'
 import { IGamingDesk } from './types'
 
 export const decksOfCardsByTier = <T extends BaseCard>(cardsArray: T[]) =>
@@ -28,26 +28,26 @@ export const decksOfCardsByTier = <T extends BaseCard>(cardsArray: T[]) =>
   )
 
 export const getNewGamingDesk = (
-  userHeadquarters: Headquarters,
-  opponentHeadquarters: Headquarters
+  userHeadquarters: Vehicle,
+  opponentHeadquarters: Vehicle
 ): IGamingDesk => ({
-  a1: null,
-  a2: null,
-  a3: null,
-  a4: null,
-  a5: opponentHeadquarters,
+  A1: null,
+  A2: null,
+  A3: null,
+  A4: null,
+  A5: opponentHeadquarters,
 
-  b1: null,
-  b2: null,
-  b3: null,
-  b4: null,
-  b5: null,
+  B1: null,
+  B2: null,
+  B3: null,
+  B4: null,
+  B5: null,
 
-  c1: userHeadquarters,
-  c2: null,
-  c3: null,
-  c4: null,
-  c5: null,
+  C1: userHeadquarters,
+  C2: null,
+  C3: null,
+  C4: null,
+  C5: null,
 })
 
 const ids = [0]
@@ -68,4 +68,11 @@ export const shuffleArray = <T>(array: T[]) => {
 
 export const getRandomInt = (max: number) => {
   return Math.floor(Math.random() * max)
+}
+
+export const getMaxMoves = (type: string) => {
+  if (type === 'лёгкий') {
+    return 2
+  }
+  return 1
 }

--- a/packages/client/src/utils/canvasEngine/canvasElement.ts
+++ b/packages/client/src/utils/canvasEngine/canvasElement.ts
@@ -1,25 +1,44 @@
-import { Tank } from '../../gameCore/models/TanksDeck'
+import { GameDeskSegmentKeyType } from '../../gameCore/types'
 import { BattleCardIcons, DPI_HEIGHT, IconsByName } from '../consts'
 
 export interface IElementsCreator {
   type: string
-  tank: Tank
-  targetСell: string
+  targetСell: GameDeskSegmentKeyType
+  tankName: string
+  tankBringsResources: number
+  tankDamage: number
+  tankHealth: number
+  tankType: string
 }
 
 export class ElementsCreator {
-  targetСell: string
-  type: string
-  tank: Tank
-  imgSrc: string
-  headImgSrc: string
+  public targetСell
+  public type
+  private imgSrc
+  private headImgSrc
+  private tankName
+  private tankBringsResources
+  private tankDamage
+  private tankHealth
+  private headTextFillStyle = false
 
-  constructor({ type, tank, targetСell }: IElementsCreator) {
+  constructor({
+    type,
+    tankName,
+    tankHealth,
+    tankType,
+    tankDamage,
+    tankBringsResources,
+    targetСell,
+  }: IElementsCreator) {
     this.targetСell = targetСell
     this.type = type
-    this.tank = tank
-    this.imgSrc = (IconsByName as Record<string, string>)[tank.name]
-    this.headImgSrc = (BattleCardIcons as Record<string, string>)[tank.type]
+    this.tankName = tankName
+    this.tankBringsResources = tankBringsResources
+    this.tankDamage = tankDamage
+    this.tankHealth = tankHealth
+    this.imgSrc = (IconsByName as Record<string, string>)[tankName]
+    this.headImgSrc = (BattleCardIcons as Record<string, string>)[tankType]
   }
 
   getElement() {
@@ -41,33 +60,41 @@ export class ElementsCreator {
       },
       headIconImg: { w: 20, h: 18, dx: 3, dy: 10, src: this.headImgSrc },
       headText: {
-        text: this.tank.name,
+        text: this.tankName,
         dx: 25,
         dy: 25,
-        font: '10pt Arial',
-        fillStyle: 'gray',
+        font: '15px Arial',
+        fillStyle: this.headTextFillStyle ? 'red' : 'gray',
       },
       bringsResourcesText: {
-        text: this.tank.bringsResources.toString(),
+        text: this.tankBringsResources.toString(),
         dx: 145,
         dy: 31,
         font: 'bold 18px Arial',
         fillStyle: '#000',
       },
       damage: {
-        text: this.tank.damage.toString(),
+        text: this.tankDamage.toString(),
         dx: 12,
         dy: 105,
         font: 'bold 18px Arial',
         fillStyle: '#64CB3E',
       },
       health: {
-        text: this.tank.health.toString(),
-        dx: 12,
+        text: this.tankHealth.toString(),
+        dx: this.tankHealth > 9 ? 8 : 12,
         dy: 145,
-        font: 'bold 18px Arial',
+        font: 'bold 16px Arial',
         fillStyle: '#fff',
       },
     }
+  }
+
+  toggleActiveElementState() {
+    this.headTextFillStyle = !this.headTextFillStyle
+  }
+
+  moveActiveElement(target: GameDeskSegmentKeyType) {
+    this.targetСell = target
   }
 }

--- a/packages/client/src/utils/consts.ts
+++ b/packages/client/src/utils/consts.ts
@@ -68,7 +68,7 @@ export const fieldsIcons = [
 ]
 
 export enum BattleCardIcons {
-  training = '/cards/icons/head-icon.png',
+  учебный = '/cards/icons/head-icon.png',
   тяжёлый = '/cards/icons/tt-icon.png',
   'ПТ-САУ' = '/cards/icons/pt-icon.png',
   лёгкий = '/cards/icons/lt-icon.png',


### PR DESCRIPTION
Облегчил движок канваса, забрал у него логику за которую отвечает движок игры.
Заменил массив элементов для канваса на объект игрового стола.
Убрал захаркоженые елементы
Теперь данные для канваса хранятся в скинах карточек.
Скины выдаются карточкам при выкладке на поле.
Там же настроена система ограничения хода, при выкладке и во время игры.
Ограничения направления движения только предстоит внести
Создана система свой-чужой
Её отрисовку (внешние признаки) - добавлю в задачу про оптимизацию канваса.
Добавлено ограничение плацдарма - выкладывать технику можно только рядом со своим штабом. Нужно будет делать систему подсказок юзеру - подсветку возможных ходов, но это скорее всего когда вся игра будет готова.
Закончена настройка стартового состояния, теперь автоматически нужные штабы выставляются на карту при старте.
Заложена система для написания логики взаимодействия карточек.

Код все еще в рабочем состоянии, например функция отслеживания клика по канвасу - превращается в монстра. Пока мне удобнее работать так - когда все в одном месте, но на следующих этапах я естественно её декомпозирую и оптимизирую.