### PR TITLE
YA-75 docker compose

### DIFF
--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -22,9 +22,13 @@ async function startServer() {
   const port = Number(process.env.SERVER_PORT) || 3001
 
   let vite: ViteDevServer | undefined
-  const distPath = path.dirname(require.resolve('client/dist/index.html'))
-  const srcPath = path.dirname(require.resolve('client'))
-  const ssrClientPath = require.resolve('client/ssr-dist/ssr.cjs')
+  // const distPath = path.dirname(require.resolve('client/dist/index.html'))
+  // const srcPath = path.dirname(require.resolve('client'))
+  // const ssrClientPath = require.resolve('client/ssr-dist/ssr.cjs')
+
+  const distPath = path.dirname('../client/dist/index.html')
+  const srcPath = path.dirname('../client')
+  const ssrClientPath = '../client/ssr-dist/ssr.cjs'
 
   if (isDev()) {
     vite = await createViteServer({


### PR DESCRIPTION
### Какую задачу решаем
YA-75 docker compose
Запуск проект в разных контейнерах.

первое изменить в .env иначе не будет работать БД в контейнерах.
`POSTGRES_HOST=postgres`

локально возвращаем на
`POSTGRES_HOST='localhost'`

для запуска контейнеров из корня проекта запускаем
`docker compose up -d server`

Запустятся все контейнеры: клиент, БД, сервер, pgadmin.

клиент
`localhost:3000`

не стал убирать пока запуск, хотя он нам не нужен, он просто собирает клиента и кладет в папку client, которая доступна для сервера через volumes


сервер
`localhost:3001`

Первый запуск проходит можно переходить по страницам, но стоит обновить страницу появляется ошибка на скрине ниже.


Docker.client отвечает за сборку клиента и размещает сборку в папке client, которая является Volumes - доступен для чтения и записи.
Docker.server отвечает за сборку сервера и забирает данные из папки client, через Volumes - доступен только для чтения.

Ранее была попытка в packages.json сервера зависимости от клиента, но это не помогло, ошибка сохранялась.

Сделать сборку ssr client сделать автономной не получилось.

### Скриншоты/видяшка (если есть)

### TBD (если есть)
![2023-01-25_17-37-49](https://user-images.githubusercontent.com/89699295/214593398-61adbd37-efd5-47d2-8ca0-7e8a386101d8.png)
